### PR TITLE
Added deletion of users' PMs in usernuke plugin

### DIFF
--- a/plugins/usernuke/page_nuke.php
+++ b/plugins/usernuke/page_nuke.php
@@ -44,6 +44,14 @@ if(isset($_POST["currpassword"]))
 		//Delete usercomments by user or to user
 		query("delete from {usercomments}
 				where uid={0} or cid={0}", $uid);
+		//Delete all of their private messages
+		$delID = query("select id from {pmsgs} where userfrom={0}", $uid);
+		if ($result->num_rows > 0) {
+			while($delID = $toDelID->fetch_assoc()) {
+			query("delete from {pmsgs_text} where pid={0}", $todelID);
+			}
+		} else {}
+		query("delete from {pmsgs} where userfrom={0}", $uid);
 
 		//Delete THE USER ITSELF
 		query("delete from {users}

--- a/plugins/usernuke/page_nuke.php
+++ b/plugins/usernuke/page_nuke.php
@@ -45,12 +45,7 @@ if(isset($_POST["currpassword"]))
 		query("delete from {usercomments}
 				where uid={0} or cid={0}", $uid);
 		//Delete all of their private messages
-		$delID = query("select id from {pmsgs} where userfrom={0}", $uid);
-		if ($result->num_rows > 0) {
-			while($delID = $toDelID->fetch_assoc()) {
-			query("delete from {pmsgs_text} where pid={0}", $todelID);
-			}
-		} else {}
+		$delID = query("DELETE pt FROM pmsgs_text LEFT JOIN pmsgs p ON pt.pid = p.id WHERE p.userfrom = {0}", $uid);
 		query("delete from {pmsgs} where userfrom={0}", $uid);
 
 		//Delete THE USER ITSELF

--- a/plugins/usernuke/page_nuke.php
+++ b/plugins/usernuke/page_nuke.php
@@ -45,7 +45,7 @@ if(isset($_POST["currpassword"]))
 		query("delete from {usercomments}
 				where uid={0} or cid={0}", $uid);
 		//Delete all of their private messages
-		$delID = query("DELETE pt FROM pmsgs_text LEFT JOIN pmsgs p ON pt.pid = p.id WHERE p.userfrom = {0}", $uid);
+		query("DELETE pt FROM pmsgs_text LEFT JOIN pmsgs p ON pt.pid = p.id WHERE p.userfrom = {0}", $uid);
 		query("delete from {pmsgs} where userfrom={0}", $uid);
 
 		//Delete THE USER ITSELF

--- a/plugins/usernuke/plugin.settings
+++ b/plugins/usernuke/plugin.settings
@@ -1,2 +1,2 @@
 name=User Nuke
-description=Adds a button to nuke a user (Removes all threads, posts, usercomments, bans and IP-bans)
+description=Adds a button to nuke a user on their profile page (Removes all threads, posts, private messages, usercomments, bans and IP-bans)


### PR DESCRIPTION
Added the deletion of the nuked users' PMs. This is in-case they used a PM spam script on any user of the site. This is in effect as plugins/usernuke/page_nuke.php. This affects the usernuke plugin.